### PR TITLE
Don't send emails twice

### DIFF
--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -13,7 +13,6 @@ class Assessment < ApplicationRecord
   include AASM
   
   before_update :transition_state
-  after_update :send_email, if: Proc.new { |a| a.complete? }
   has_many :assessment_answers
   belongs_to :user, optional: true
   
@@ -160,10 +159,6 @@ class Assessment < ApplicationRecord
     
     def error_message(attribute, count)
       I18n.t("activerecord.errors.models.assessment.attributes.#{attribute}.count", count: count)
-    end
-    
-    def send_email
-      SendEmail.enqueue('UserMailer', :send_results, user.id)
     end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,7 +23,7 @@ class User < ApplicationRecord
   validates :email, email: true
   
   def can_send_email?
-    !assessment.nil? && assessment.complete?
+    !assessment.nil? && assessment.complete? && !email_sent?
   end
   
   private
@@ -34,6 +34,7 @@ class User < ApplicationRecord
   
     def send_email
       SendEmail.enqueue('UserMailer', :send_results, id)
+      update_column :email_sent, true
     end
   
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   has_one :assessment
   belongs_to :team, optional: true
+  after_save :send_email, if: Proc.new { |u| u.can_send_email? }
   
   ORGANISATION_TYPES = [
     'Multi-national Government',
@@ -20,5 +21,19 @@ class User < ApplicationRecord
   COUNTRIES = ISO3166::Country.codes
   
   validates :email, email: true
+  
+  def can_send_email?
+    !assessment.nil? && assessment.complete?
+  end
+  
+  private
+    
+    def email_sent?
+      email_sent === true
+    end
+  
+    def send_email
+      SendEmail.enqueue('UserMailer', :send_results, id)
+    end
   
 end

--- a/db/migrate/20171116184710_add_email_sent_to_users.rb
+++ b/db/migrate/20171116184710_add_email_sent_to_users.rb
@@ -1,0 +1,5 @@
+class AddEmailSentToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :email_sent, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171116115828) do
+ActiveRecord::Schema.define(version: 20171116184710) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 20171116115828) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "colour"
   end
 
   create_table "assessment_answers", force: :cascade do |t|
@@ -87,6 +88,7 @@ ActiveRecord::Schema.define(version: 20171116115828) do
     t.datetime "updated_at", null: false
     t.integer "team_id"
     t.string "locale", default: "en", null: false
+    t.boolean "email_sent", default: false, null: false
   end
 
 end

--- a/spec/controllers/assessments_controller_spec.rb
+++ b/spec/controllers/assessments_controller_spec.rb
@@ -178,6 +178,24 @@ RSpec.describe AssessmentsController, type: :controller do
       expect(assessment.weak_attitudes.count).to eq(1)
     end
     
+    it 'creates a user' do
+      assessment.update_column(:aasm_state, 'weak_attitudes_added')
+      params[:assessment][:user_attributes] = {
+        email: 'me@example.com'
+      }
+      put :update, params: params
+      assessment.reload
+      expect(assessment.user).to_not be_nil
+    end
+    
+    it 'triggers an email' do
+      assessment.update_column(:aasm_state, 'weak_attitudes_added')
+      params[:assessment][:user_attributes] = {
+        email: 'me@example.com'
+      }
+      expect { put :update, params: params }.to change { ActionMailer::Base.cached_deliveries.count }.by(1)
+    end
+    
     it 'goes back' do
       assessment.update_column(:aasm_state, 'strong_attitudes_added')
       params[:back] = 1

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -165,21 +165,4 @@ RSpec.describe Assessment, type: :model do
     
   end
   
-  it 'sends an email when the assessment is complete' do
-    assessment.aasm_state = 'weak_attitudes_added'
-    expect { assessment.save }.to change { ActionMailer::Base.cached_deliveries.count }.by(1)
-  end
-  
-  it 'does not send an email for any other state' do
-    [
-      'start',
-      'strong_skills_added',
-      'weak_skills_added',
-      'strong_attitudes_added'
-    ].each do |state|
-      assessment.aasm_state = state
-      expect { assessment.save }.to change { ActionMailer::Base.cached_deliveries.count }.by(0)
-    end
-  end
-  
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -106,6 +106,19 @@ RSpec.describe User, type: :model do
       expect { FactoryBot.create(:assessment, user: user) }.to change { ActionMailer::Base.cached_deliveries.count }.by(0)
     end
     
+    it 'does not send an email if the email sent boolean is true' do
+      user = FactoryBot.create(:user, email_sent: true)
+      user.assessment = FactoryBot.create(:assessment, aasm_state: 'complete')
+      expect { user.save }.to change { ActionMailer::Base.cached_deliveries.count }.by(0)
+    end
+    
+    it 'updates the email_sent column' do
+      user = FactoryBot.create(:user)
+      user.assessment = FactoryBot.create(:assessment, aasm_state: 'complete')
+      user.save
+      expect(user.email_sent).to eq(true)
+    end
+    
   end
   
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -89,5 +89,23 @@ RSpec.describe User, type: :model do
     
   end
   
+  describe '#send_email' do
+    
+    it 'sends an email when the user has a complete assessment applied' do
+      user = FactoryBot.create(:user)
+      user.assessment = FactoryBot.create(:assessment, aasm_state: 'complete')
+      expect { user.save }.to change { ActionMailer::Base.cached_deliveries.count }.by(1)
+    end
+    
+    it 'does not send an email if the user does not have an assessment' do
+      expect { FactoryBot.create(:user) }.to change { ActionMailer::Base.cached_deliveries.count }.by(0)
+    end
+    
+    it 'does not send an email when the user has an incomplete assessment applied' do
+      user = FactoryBot.create(:user)
+      expect { FactoryBot.create(:assessment, user: user) }.to change { ActionMailer::Base.cached_deliveries.count }.by(0)
+    end
+    
+  end
   
 end


### PR DESCRIPTION
We now send the emails via a callback on the user model. This only happens when a user is created or updated via a completed assessment, so when a user is created via a Team, they only get emailed once they complete their assessment.

I've also added a belt and braces boolean flag in the database so if the user gets saved again, the email won't be triggered a second time.